### PR TITLE
docs: add 'How to Run' section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # chichewa-news-scraper
 Creating Chichewa Datasets for Generative Models
+## 🚀 How to Run
+
+1.  **Clone the repository**
+    ```bash
+    git clone https://github.com/YourGitHubUsername/chichewa-news-scraper.git
+    cd chichewa-news-scraper
+    ```
+
+2.  **Install dependencies**
+    It is recommended to use a virtual environment.
+    ```bash
+    python -m venv venv
+    source venv/bin/activate  # On Windows: venv\Scripts\activate
+    pip install -r requirements.txt
+    ```
+
+3.  **Run the scraper**
+    ```bash
+    python scraper.py
+    ```


### PR DESCRIPTION
This PR adds a simple "How to Run" section to the README to help new contributors get the project running quickly. It includes steps for cloning, setting up a virtual environment, and running the scraper.